### PR TITLE
Fix typo in page title and file name

### DIFF
--- a/content/docs/Installation/lomorage-client/installation-android.md
+++ b/content/docs/Installation/lomorage-client/installation-android.md
@@ -1,5 +1,5 @@
 ---
-title: Andriod
+title: Android
 weight: 2
 ---
 


### PR DESCRIPTION
Replacing "Andriod" with "Android".